### PR TITLE
Add hook before account creation

### DIFF
--- a/bureau/class/m_admin.php
+++ b/bureau/class/m_admin.php
@@ -638,6 +638,16 @@ class m_admin {
             $msg->raise("ERROR", "admin", _("Login can only contains characters a-z, 0-9 and -"));
             return false;
         }
+        // Additional checks before a user is created
+        // Do not create the account if any hook returned false
+        $before_add_hook_data = $hooks->invoke('hook_before_alternc_add_member', [$login]);
+        foreach($before_add_hook_data as $create) {
+          if(!$create) {
+              $msg->raise("ERROR", "admin", _("-- I cannot create this account --"));
+              return false;
+          }
+        }
+
         $pass = password_hash($pass, PASSWORD_BCRYPT);
         $db = new DB_System();
         // Already exist?

--- a/bureau/class/m_admin.php
+++ b/bureau/class/m_admin.php
@@ -639,13 +639,14 @@ class m_admin {
             return false;
         }
         // Additional checks before a user is created
-        // Do not create the account if any hook returned false
+        // Do not create the account if any hook has a return value
+        // The returned value should provide additional information
         $before_add_hook_data = $hooks->invoke('hook_before_alternc_add_member', [$login]);
         foreach($before_add_hook_data as $create) {
-          if(!$create) {
-              $msg->raise("ERROR", "admin", _("-- I cannot create this account --"));
-              return false;
-          }
+	    if($create !== null) {
+		$msg->raise("ERROR", "admin", _("The account '%s' cannot be created. %s"), [$login, $create]);
+		return false;
+	    }
         }
 
         $pass = password_hash($pass, PASSWORD_BCRYPT);

--- a/bureau/locales/README
+++ b/bureau/locales/README
@@ -8,7 +8,7 @@ dans lequel on a des fichiers .po en vrac (normalement 1 ou 2 fichiers .po par m
 
 Le fichier alternc.mo est donc construit à partir de TOUS les fichiers .po d'une même langue.
 
-Pour mettre a jour les fichiers .po a partir des sources : 
+Pour mettre a jour les fichiers .po a partir des sources (avoir le paquet gettext):
 
 cd bureau/locales
 make 
@@ -36,7 +36,7 @@ to translate AlternC in any language.
 When the programm is updated, the po files in locales/ are changed to
 reflect the new developped features.
 
-You can just call the makefile to have the files regenerated:
+You can just call the makefile to have the files regenerated (you'll need the gettext package):
 
 cd bureau/locales
 make

--- a/bureau/locales/en_US/LC_MESSAGES/manual.po
+++ b/bureau/locales/en_US/LC_MESSAGES/manual.po
@@ -72,6 +72,10 @@ msgstr "This TLD already exists"
 msgid "err_admin_13"
 msgstr "The login is too long (16 chars max)"
 
+#. The account '%s' cannot be created. %s
+msgid "err_admin_19"
+msgstr "The account '%s' cannot be created. %s"
+
 #. Domain names
 msgid "quota_dom"
 msgstr "Domain names"

--- a/bureau/locales/en_US/LC_MESSAGES/messages.po
+++ b/bureau/locales/en_US/LC_MESSAGES/messages.po
@@ -4691,6 +4691,10 @@ msgstr ""
 msgid "Login can only contains characters a-z, 0-9 and -"
 msgstr ""
 
+#: ../class/m_admin.php:647
+msgid "The account '%s' cannot be created. %s"
+msgstr ""
+
 #: ../class/m_admin.php:672
 msgid "This login already exists"
 msgstr ""

--- a/bureau/locales/es_ES/LC_MESSAGES/messages.po
+++ b/bureau/locales/es_ES/LC_MESSAGES/messages.po
@@ -5097,6 +5097,10 @@ msgstr ""
 msgid "Login can only contains characters a-z, 0-9 and -"
 msgstr ""
 
+#: ../class/m_admin.php:647
+msgid "The account '%s' cannot be created. %s"
+msgstr ""
+
 #: ../class/m_admin.php:672
 msgid "This login already exists"
 msgstr ""

--- a/bureau/locales/fr_FR/LC_MESSAGES/manual.po
+++ b/bureau/locales/fr_FR/LC_MESSAGES/manual.po
@@ -74,6 +74,10 @@ msgstr "Ce TLD existe déjà"
 msgid "err_admin_13"
 msgstr "Le login est trop long (16 caractères maximum)"
 
+#. The account '%s' cannot be created. %s
+msgid "err_admin_19"
+msgstr "Le compte '%s' ne peut être créé. %s"
+
 #. Domain names
 msgid "quota_dom"
 msgstr "Noms de domaines"

--- a/bureau/locales/fr_FR/LC_MESSAGES/messages.po
+++ b/bureau/locales/fr_FR/LC_MESSAGES/messages.po
@@ -1601,18 +1601,22 @@ msgid "Quit"
 msgstr "Fermer"
 
 #: ../admin/bro_main.php:73
+#, php-format
 msgid "The folder '%s' was successfully created"
 msgstr "Le dossier %s a été effacé avec succès"
 
 #: ../admin/bro_main.php:79
+#, fuzzy, php-format
 msgid "The file '%s' was successfully created"
 msgstr "Le fihier été créé avec succès"
 
 #: ../admin/bro_main.php:94
+#, php-format
 msgid "The folder '%s' was successfully deleted"
 msgstr "Le dossier %s a été effacé avec succès"
 
 #: ../admin/bro_main.php:96
+#, php-format
 msgid "The file '%s' was successfully deleted"
 msgstr "Le fichier %s a été effacé avec succès"
 
@@ -1663,10 +1667,12 @@ msgid "The files / folders were successfully moved"
 msgstr "Les fichiers /  répertoires %s ont été déplacé avec succès"
 
 #: ../admin/bro_main.php:153
+#, php-format
 msgid "The folder '%s' was successfully renamed to '%s'"
 msgstr "Le dossier '%s' a été renommé '%s' avec succès"
 
 #: ../admin/bro_main.php:155
+#, php-format
 msgid "The file '%s' was successfully renamed to '%s'"
 msgstr "Le fichier '%s' a été renommé '%s' avec succès"
 
@@ -1675,6 +1681,7 @@ msgid "The files / folders were successfully renamed"
 msgstr "Les fichiers / répertoires ont été renommés avec succès"
 
 #: ../admin/bro_main.php:162
+#, php-format
 msgid "The file '%s' was successfully uploaded"
 msgstr "Le fichier '%s' a été téléversé avec succès"
 
@@ -1683,6 +1690,7 @@ msgid "The permissions were successfully set"
 msgstr "Les permissions ont été appliquées avec succès"
 
 #: ../admin/bro_main.php:175
+#, php-format
 msgid "The extraction of the file '%s' succeeded"
 msgstr "L'extraction du fichier '%s' a été effectuée avec succés"
 
@@ -2702,10 +2710,12 @@ msgid "Folder %s is protected"
 msgstr ""
 
 #: ../admin/hta_doadduser.php:45
+#, php-format
 msgid "The user %s was added to the protected folder %s"
 msgstr "L'utilisateur %s a été ajouté au répertoire protégé %s"
 
 #: ../admin/hta_dodeluser.php:39
+#, php-format
 msgid "The user '%s' was successfully deleted"
 msgstr "L'utilisateur %s a été effacée avec succès"
 
@@ -4260,6 +4270,7 @@ msgid "Create this new MySQL user"
 msgstr "Créer ce nouvel utilisateur MySQL"
 
 #: ../admin/sql_users_del.php:38 ../class/m_mysql.php:770
+#, php-format
 msgid "The user '%s' has been successfully deleted"
 msgstr "L'utilisateur MySQL %s a été effacé avec succès"
 
@@ -4280,10 +4291,12 @@ msgid "Yes, delete the MySQL user"
 msgstr "Oui, effacer cet utilisateur MySQL"
 
 #: ../admin/sql_users_doadd.php:41 ../admin/sql_users_doadd.php:50
+#, php-format
 msgid "The user '%s' has been successfully created."
 msgstr "L'utilisateur %s a été ajouté avec succès"
 
 #: ../admin/sql_users_dopassword.php:35
+#, php-format
 msgid "Password changed for user '%s'."
 msgstr "Mot de passe changé pour l'utilisateur '%s'."
 
@@ -4983,6 +4996,10 @@ msgstr "Le nom d'utilisateur est trop long (14 caractères maximum)"
 #: ../class/m_admin.php:633
 msgid "Login can only contains characters a-z, 0-9 and -"
 msgstr "Le nom d'utilisateur ne peut contenir que les caractères a-z, 0-9 et -"
+
+#: ../class/m_admin.php:647
+msgid "The account '%s' cannot be created. %s"
+msgstr "Le compte '%s' ne peut être créé. %s"
 
 #: ../class/m_admin.php:672
 msgid "This login already exists"

--- a/bureau/locales/it_IT/LC_MESSAGES/messages.po
+++ b/bureau/locales/it_IT/LC_MESSAGES/messages.po
@@ -4677,6 +4677,10 @@ msgstr ""
 msgid "Login can only contains characters a-z, 0-9 and -"
 msgstr ""
 
+#: ../class/m_admin.php:647
+msgid "The account '%s' cannot be created. %s"
+msgstr ""
+
 #: ../class/m_admin.php:672
 msgid "This login already exists"
 msgstr ""

--- a/bureau/locales/messages.pot
+++ b/bureau/locales/messages.pot
@@ -4677,6 +4677,10 @@ msgstr ""
 msgid "Login can only contains characters a-z, 0-9 and -"
 msgstr ""
 
+#: ../class/m_admin.php:647
+msgid "The account '%s' cannot be created. %s"
+msgstr ""
+
 #: ../class/m_admin.php:672
 msgid "This login already exists"
 msgstr ""

--- a/bureau/locales/nl_NL/LC_MESSAGES/messages.po
+++ b/bureau/locales/nl_NL/LC_MESSAGES/messages.po
@@ -4677,6 +4677,10 @@ msgstr ""
 msgid "Login can only contains characters a-z, 0-9 and -"
 msgstr ""
 
+#: ../class/m_admin.php:647
+msgid "The account '%s' cannot be created. %s"
+msgstr ""
+
 #: ../class/m_admin.php:672
 msgid "This login already exists"
 msgstr ""

--- a/bureau/locales/pt_BR/LC_MESSAGES/messages.po
+++ b/bureau/locales/pt_BR/LC_MESSAGES/messages.po
@@ -5030,6 +5030,10 @@ msgstr ""
 msgid "Login can only contains characters a-z, 0-9 and -"
 msgstr ""
 
+#: ../class/m_admin.php:647
+msgid "The account '%s' cannot be created. %s"
+msgstr ""
+
 #: ../class/m_admin.php:672
 msgid "This login already exists"
 msgstr ""

--- a/lang/en_US.po
+++ b/lang/en_US.po
@@ -5767,6 +5767,10 @@ msgstr ""
 msgid "Login can only contains characters a-z, 0-9 and -"
 msgstr ""
 
+#: ../class/m_admin.php:647
+msgid "The account '%s' cannot be created. %s"
+msgstr ""
+
 #: ../class/m_admin.php:672
 msgid "This login already exists"
 msgstr ""

--- a/lang/nl_NL.po
+++ b/lang/nl_NL.po
@@ -5764,6 +5764,10 @@ msgstr ""
 msgid "Login can only contains characters a-z, 0-9 and -"
 msgstr "In de login kunnen alleen gebruikt worden a-z, 0-9 en -"
 
+#: ../class/m_admin.php:647
+msgid "The account '%s' cannot be created. %s"
+msgstr ""
+
 #: ../class/m_admin.php:672
 msgid "This login already exists"
 msgstr "Deze login bestaat al"


### PR DESCRIPTION
Adding a hook before an account is created so that classes - such as m_nss.php when using alternc_nss - can prevent account creation.